### PR TITLE
Fix chromium lambda builds

### DIFF
--- a/packages/lambda/builds/chromium/build/build.sh
+++ b/packages/lambda/builds/chromium/build/build.sh
@@ -30,7 +30,7 @@ yum install -y \
   libffi-devel libgcc libgnome-keyring-devel libjpeg-devel libstdc++ libuuid-devel \
   libX11-devel libxkbcommon-x11-devel libXScrnSaver-devel libXtst-devel mercurial \
   mod_ssl ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel \
-  pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python \
+  pciutils-devel php php-cli pkgconfig pulseaudio-libs-devel python python3 \
   tar zlib zlib-devel
 
 mkdir -p build/chromium


### PR DESCRIPTION
I'd like to thank you for this amazing project.

Yesterday, I tried to build my own binary, but the script **build.sh** located in the lambda builds package crashes at some point before starting to compile Chromium. The exception says there are no **python3** in the host image to perform some downloads from Google storage.

I think it's happening the same during the CI/CD Pipeline, so i added it to the package list and tried again.

The build was successful after 5h 30m in a laptop with Intel Core i5 9300H / 16 GB RAM.

![build1](https://user-images.githubusercontent.com/6425132/121812904-64b45080-cc2f-11eb-90d5-03ed1c9d35e8.PNG)
